### PR TITLE
Consider status code != 2xx as failures

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ var (
 )
 
 func init() {
+	// version.NewCollector(namespace) doesn't give us good information at the moment because our
+	// build pipeline doesn't pass version, nor commit SHA as build arguments
 	prometheus.MustRegister(version.NewCollector(namespace))
 	prometheus.MustRegister(requestsFailed)
 	prometheus.MustRegister(requestsDuration)
@@ -103,6 +105,10 @@ func Probe() error {
 		return fmt.Errorf("Failed request for url: %s", probeURL)
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode > 299 {
+		requestsFailed.Inc()
+	}
 
 	level.Info(logger).Log("msg", "Probed", "url", probeURL, "code", res.StatusCode)
 	requestsDuration.Observe(duration)


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
I remember that blackbox exporter would see some small failures every now and then, but since we introduced http-prober I haven't seen any failures **_at all_**.

I took a quick look at the code again and I noticed that I forgot to check for status code 🤦